### PR TITLE
Flow title on compare page became the link

### DIFF
--- a/templates/flows_compare.html
+++ b/templates/flows_compare.html
@@ -4,7 +4,7 @@
 {% for flow in flows %}
     <div style="float: left; margin: 50px">
         <br>
-        <i>{{ flow.name }}</i>
+        <a href="/flows/{{ flow.id }}">{{ flow.name }}</a>
         <br/>
         {% for step in flow.steps %}
         <div>Stepname: {{ step.name }}</div>


### PR DESCRIPTION
- Fixes #39 
- Flow title on compare page became the link and user can click and back to the flow page.